### PR TITLE
Fix timeout bug

### DIFF
--- a/bot-files/brainfuck.js
+++ b/bot-files/brainfuck.js
@@ -72,7 +72,7 @@ module.exports = {
       while (pos < Instructions.length){
         await Apply_Command(bot, msg, Instructions[pos], silent)
         pos++
-        if (Date.now() - start > TIME_LIMIT) {
+        if (Date.now() - start > TIME_LIMIT){
           Instructions = []
           return `Time Limit Exceded\nOutput: ${Output}\nCell: ${Cell}\nMemory: ${Mem}`
         }

--- a/bot-files/brainfuck.js
+++ b/bot-files/brainfuck.js
@@ -68,11 +68,14 @@ module.exports = {
     function: async function(bot, msg, args, debug, silent){
       if (Instructions.length) return // prevents executing input as code (if every message is compiled)
       Init(msg.content)
-      var start = new Date()
+      const start = Date.now()
       while (pos < Instructions.length){
         await Apply_Command(bot, msg, Instructions[pos], silent)
         pos++
-        if (new Date() - start > TIME_LIMIT) return `Time Limit Exceded\nOutput: ${Output}\nCell: ${Cell}\nMemory: ${Mem}`
+        if (Date.now() - start > TIME_LIMIT) {
+          Instructions = []
+          return `Time Limit Exceded\nOutput: ${Output}\nCell: ${Cell}\nMemory: ${Mem}`
+        }
       }
       if (debug===undefined) debug = true
       if (debug) Output = `Output: ${Output}\nCell: ${Cell}\nMemory: ${Mem}`


### PR DESCRIPTION
When timeouts happen, `Instructions` doesn't reset. So the if statement on line 69 prevents future execution. This fixes the bug by resetting Instructions on timeout.

 I'm not sure why the if statement or `Instructions` exists, but I left them there anyway. (I dont understand the comment; strings support indexing)

new Date --> Date.now