### PR TITLE
Build known CRC map from filesystem

### DIFF
--- a/bot-files/m64_editor.js
+++ b/bot-files/m64_editor.js
@@ -3,6 +3,7 @@
 const fs = require('fs')
 const users = require('./users.js')
 const save = require('./save.js')
+const roms = require('./roms.js')
 const cp = require('child_process')
 const process = require('process')
 const request = require('request')
@@ -377,9 +378,10 @@ function NextProcess(bot, retry = true) {
                     `ERROR: unknown CRC ${crc} when running Mupen\n${JSON.stringify(request)}`
                 )
             } else {
+                const formattedCRC = roms.formatCRC(Number(crc))
                 bot.createMessage(
                     request.channel_id,
-                    `<@${request.user_id}> Unknown CRC: ${crc}. For a list of supported games, use $ListCRC`
+                    `<@${request.user_id}> The movie you provided belongs to an unsupported ROM with CRC \`${formattedCRC}\`.\nFor a list of supported ROMs, use the \`$ListCRC\` command.`
                 )
             }
             MupenQueue.shift() // this request cannot be run
@@ -1526,12 +1528,17 @@ module.exports = {
             'Shows a list of ROM CRCs that the `$encode` command supports. If there is a game that you would like added to this list, please contact the owner of this bot',
         hidden: true,
         function: async function (bot, msg, args) {
-            var result = 'CRC: ROM Name\n' + '```'
-            var crc = Object.keys(KNOWN_CRC)
-            for (var i = 0; i < crc.length; i++) {
-                result += `${crc[i]}: ${KNOWN_CRC[crc[i]]}\n`
-            }
-            return result + '```'
+            let result = 'CRC: ROM Name\n'
+
+            result += '```\n'
+            Object.keys(KNOWN_CRC).forEach((pair) => {
+                const formattedCRC = roms.formatCRC(Number(pair))
+                const filename = KNOWN_CRC[pair]
+                result += `${formattedCRC}: ${filename}\n`
+            });
+            result += '```'
+            
+            return result
         },
     },
 

--- a/bot-files/roms.js
+++ b/bot-files/roms.js
@@ -1,0 +1,40 @@
+const fs = require('fs')
+const path = require('path')
+
+module.exports = {
+    /**
+     * Reads all ROM files in a directory and builds a mapping of CRC32 checksums to ROM names.
+     * @param {*} directoryPath Path to the directory containing ROM files.
+     * @returns {Object} An object mapping CRC32 checksums to ROM names.
+     */
+    getKnownCRCsFromROMsInDirectory: (directoryPath) => {
+        const known_crcs = {}
+
+        const romFilenames = fs.readdirSync(directoryPath)
+        romFilenames.forEach(file => {
+            const filePath = path.join(directoryPath, file)
+            const fileBuffer = fs.readFileSync(filePath)
+
+            if (fileBuffer.length < 20) {
+                console.error(`File too small: ${file} (${fileBuffer.length} bytes)`);
+                return;
+            }
+
+            const crc = fileBuffer.readUInt32BE(16)
+            const romName = path.parse(file).name
+
+            known_crcs[crc] = romName
+        });
+        return known_crcs
+    },
+
+    /**
+     * Formats a CRC value into a standardized string representation.
+     * @param {*} crc CRC value to format.
+     */
+    formatCRC: (crc) => {
+        return [0, 8, 16, 24]
+            .map(shift => ((crc >>> shift) & 0xFF).toString(16).padStart(2, '0').toUpperCase())
+            .join(' ');
+    }
+}

--- a/saves_template/m64.json
+++ b/saves_template/m64.json
@@ -1,18 +1,4 @@
 {
-    "CRC": {
-        "FF 2B 5A 63": "Super Mario 64 (USA)",
-        "0E 3D AA 4E": "Super Mario 64 (JP)",
-        "E2 23 33 F9": "Ghost Race Transparent (v3)",
-        "8D 3C 49 DC": "Last Impact (1.2)",
-        "88 60 DB 69": "Shining Stars Repainted (1.1)",
-        "BC B0 D5 1E": "Green Comet (1.0.1)",
-        "8B 70 48 88": "The Green Stars (1.3)",
-        "34 13 32 75": "Another Mario Adventure (1.10)",
-        "89 96 84 12": "Another Mario Adventure (1.11)",
-        "F5 FF C3 A7": "No Speed Limit 64 (B-Speed)",
-        "31 E0 AD FA": "Star Road (1.0.1)",
-        "A7 43 11 0F": "Mario Party 64 (1.1.2)"
-    },
     "MupenPath": "C:\\MupenServerFiles\\1.0.7_2\\a.exe",
     "GamePath": "C:\\MupenServerFiles\\ROMs\\",
     "InputLuaPath": "C:\\MupenServerFiles\\EncodeLua\\inputs.lua",


### PR DESCRIPTION
This PR removes the built-in known CRC map and builds it at runtime instead, based on the ROMs present in the ROM directory.